### PR TITLE
Fix broken Hugo references

### DIFF
--- a/content/en/docs/measuring/measuring-ai-ml-applications.md
+++ b/content/en/docs/measuring/measuring-ai-ml-applications.md
@@ -33,6 +33,6 @@ Bonus tip: If you apply `--quick` to the `run-template.sh` call the measurement 
 
 #### Trying out our hosted service
 
-We operate [green-coding.ai](https://green-coding.ai) as a simple demo vertical that uses the underlying [Green Metrics Tool Cluster Hosted Service →]({{< relref "/docs/measuring/measuring-service/" >}}).
+We operate [green-coding.ai](https://green-coding.ai) as a simple demo vertical that uses the underlying [Green Metrics Tool Cluster Hosted Service →]({{< relref "/docs/measuring/measuring-service" >}}).
 
 Check it out if you do not feel like installing the GMT and just want to get carbon and energy info on single prompts.

--- a/content/en/docs/measuring/measuring-containers.md
+++ b/content/en/docs/measuring/measuring-containers.md
@@ -55,7 +55,7 @@ So, if you execute strange CPU instructions, such as AVX instructions or CPU ste
 
 We currently have a beta feature to be launched in Summer 2025 that utilizes AMD RAPL per-core energy registers and core-pinning to report individial container CPU energy metrics.
 
-The GMT will utilize a `taskset` to pin the container to a distinct core. Since no other processes are running on your benchmarking systems in [Green Metrics Tool Cluster Hosted Service →]({{< relref "/docs/measuring/measuring-service/" >}}) the values are very reliable.
+The GMT will utilize a `taskset` to pin the container to a distinct core. Since no other processes are running on your benchmarking systems in [Green Metrics Tool Cluster Hosted Service →]({{< relref "/docs/measuring/measuring-service" >}}) the values are very reliable.
 
 Private beta opens Summer 2025. If you are interested shoot us an email to [info@green-coding.io](mailto:info@green-coding.io)
 - The energy of the browser is measured to display and render the page

--- a/content/en/docs/measuring/measuring-websites.md
+++ b/content/en/docs/measuring/measuring-websites.md
@@ -13,7 +13,7 @@ GMT can also measure websites and takes a multi-dimensional approach here:
 
 To isolate this as best as possible GMT orchestrates a reverse proxy, warms up the cache by pre-loading the full page once and only then does the final measurement.
 
-**Warning:** Measuring websites is very tricky! GMT shaves off some of the caveats by using reverse proxys and cache pre-loading to make results more reliable. Since measurement load times are in milliseconds range you must have [Metric Providers]({{< relref "/docs/measuring/metric-providers/" >}}) with very high *sampling_rates* connected. **2ms** is a good value. Also website measurements are really only realiable in a [controlled cluster]({{< relref "/docs/cluster/" >}}) with [accuracy control]({{< relref "/docs/cluster/accuracy-control/" >}}).
+**Warning:** Measuring websites is very tricky! GMT shaves off some of the caveats by using reverse proxys and cache pre-loading to make results more reliable. Since measurement load times are in milliseconds range you must have [Metric Providers]({{< relref "/docs/measuring/metric-providers/" >}}) with very high *sampling_rates* connected. **2ms** is a good value. Also website measurements are really only realiable in a [controlled cluster]({{< relref "/docs/cluster/" >}}) with [accuracy control]({{< relref "/docs/cluster/accuracy-control" >}}).
 
 #### Quick website measuring
 
@@ -29,6 +29,6 @@ Bonus tip: If you apply `--quick` to the `run-template.sh` call the measurement 
 
 #### Trying out our hosted service
 
-We operate [website-tester.green-coding.io](https://website-tester.green-coding.io) as a simple demo vertical that uses the underlying [Green Metrics Tool Cluster Hosted Service →]({{< relref "/docs/measuring/measuring-service/" >}}).
+We operate [website-tester.green-coding.io](https://website-tester.green-coding.io) as a simple demo vertical that uses the underlying [Green Metrics Tool Cluster Hosted Service →]({{< relref "/docs/measuring/measuring-service" >}}).
 
 Check it out if you do not feel like installing the GMT and just want to get carbon and energy info on a single page.

--- a/content/en/docs/measuring/usage-scenario.md
+++ b/content/en/docs/measuring/usage-scenario.md
@@ -341,6 +341,6 @@ A run where we want the variable to be *1* as example can be started like this:
 ```bash
 $ python3 runner.py --uri PATH_TO_SCENARIO --variables "__GMT_VAR_DURATION__=1"
 ```
-See more details in [Runner switches →]({{< relref "/docs/measuring/runner-switches/" >}})
+See more details in [Runner switches →]({{< relref "/docs/measuring/runner-switches" >}})
 
 The API accepts these variables as arguments also to the `/v1/software/add` endpoint. See the [API documentation →]({{< relref "/docs/api/overview" >}}) for details.


### PR DESCRIPTION
## Summary
- fix Runner switches relref path
- fix measuring-service link paths
- update website docs to reference accuracy control page

## Testing
- `npm install`
- `./node_modules/.bin/hugo/hugo`

------
https://chatgpt.com/codex/tasks/task_e_687f3e9bf800832f8398bcde1383f9eb