### PR TITLE
Adds the carbon provider documentation

### DIFF
--- a/content/en/docs/measuring/metric-providers/carbon-intensity-electricitymaps-machine.md
+++ b/content/en/docs/measuring/metric-providers/carbon-intensity-electricitymaps-machine.md
@@ -1,0 +1,143 @@
+---
+title: "Carbon Intensity - Electricity Maps - Machine"
+description: "Documentation for CarbonIntensityElectricitymapsMachineProvider of the Green Metrics Tool"
+date: 2026-05-11T08:49:15+00:00
+weight: 220
+---
+
+### What it does
+
+This provider fetches the carbon intensity (gCO2e/kWh) of the electricity grid for a configured
+region from the [Electricity Maps API](https://www.electricitymaps.com/) and aligns the returned
+time series with the measurement window of the current run.
+
+After every run the provider queries the *past-range* endpoint of the Electricity Maps API for the
+zone configured in the `config.yml` and uses the carbon intensity data points that fall between
+the `start_profiling` and `stop_profiling` timestamps. The values are then sampled into the
+sampling rate granularity of the Green Metrics Tool and stored as a regular metric of the run.
+
+If the run is too short to produce data points on the *past-range* endpoint (the API typically lags
+by 5 minutes up to one hour, depending on the zone), the provider transparently falls back to the
+*forecast* endpoint and uses the value closest to the measurement window. This means that even
+short-running benchmarks have a carbon intensity value attached to them, although for very short
+runs this value will be a forecast rather than a measured grid value.
+
+### Classname
+
+- `CarbonIntensityElectricitymapsMachineProvider`
+
+### Metric Name
+
+- `carbon_intensity_electricity_maps_machine`
+
+### Unit
+
+- `gCO2e/kWh`
+
+The provider stores integer values. The API returns floating point numbers which are rounded to
+the nearest integer before being persisted.
+
+### Prerequisites & Installation
+
+The provider is a pure Python provider and does not need any binary to be compiled. It does however
+require network access from the measurement machine to `api.electricitymaps.com` and a valid
+Electricity Maps API token.
+
+You can obtain a free token (subject to fair-use limits) at
+[https://api-portal.electricitymaps.com/](https://api-portal.electricitymaps.com/).
+
+Please note: The free token is for non-commercial use only. If you want to use Electricity Maps
+data in a commercial context you need to acquire a commercial license from Electricity Maps.
+
+The provider must be configured in the `config.yml`:
+
+```yml
+measurement:
+  metric-providers:
+    common:
+      carbon_intensity_electricitymaps_machine:
+        region: 'DE'
+        token: 'XXXX'
+        sampling_rate: 99 # Remove if you don't want value padding
+```
+
+Please see [Configuration →]({{< relref "/docs/measuring/configuration" >}}) for further info.
+
+### Input Parameters
+
+- `region` — The Electricity Maps zone identifier (e.g. `DE`, `FR`, `US-CAL-CISO`). A list of
+  available zones can be found in the [Electricity Maps API documentation](https://portal.electricitymaps.com/docs/getting-started#geographical-coverage).
+- `token` — A valid Electricity Maps API token. Without a token the provider will refuse to start.
+- `sampling_rate` — The sampling rate in milliseconds. This value is not used to call the API more
+  frequently (the API is only called once per run) but to *pad* the returned values to the same
+  resolution as the other metric providers so that the time series can be joined cleanly.
+
+### Output
+
+The provider does not produce a continuous Stdout stream like the C-based providers. Instead, the
+data is fetched once per run from the Electricity Maps API and inserted directly into the database
+as a metric of the run.
+
+Each row consists of:
+
+- `time`: The timestamp of the data point in microseconds (UNIX epoch).
+- `value`: The carbon intensity at that point in time in `gCO2e/kWh` as an integer.
+- `detail_name`: Always `electricity_maps` to indicate the data source.
+
+Any errors that occur while talking to the API are appended to the provider's stderr buffer and can
+be inspected in the run details in the frontend.
+
+### How it works
+
+On `start_profiling` and `stop_profiling` the provider records UTC timestamps. When the metrics are
+read at the end of the run it issues a single HTTP GET request to
+
+```
+https://api.electricitymaps.com/v4/carbon-intensity/past-range
+```
+
+with the configured zone, the start/end times of the run, and a temporal granularity of 5 minutes.
+The response is a list of `{datetime, carbonIntensity}` entries which are filtered to the
+measurement window, sorted ascending in time, rounded to integer values and finally expanded to the
+configured `sampling_rate` so that the values align with the other providers' time series.
+
+If the response is empty (typically because the run finished before the grid data caught up) the
+provider falls back to the forecast endpoint
+
+```
+https://api.electricitymaps.com/v4/carbon-intensity/forecast
+```
+
+and picks the forecast value closest to the measurement window.
+
+### Health check
+
+When the provider starts, it issues a small `past-range` request for the last hour to confirm that
+the configured zone is valid and that the API token is accepted. If the API returns `401` or `403`
+the provider raises a `MetricProviderConfigurationError` with a hint that the token is incorrect.
+If the API endpoint cannot be reached at all (DNS/network issues) the same error is raised with the
+underlying exception.
+
+### Caveats
+
+- The provider requires network access during the run. If the measurement machine is air-gapped
+  this provider will not work. Use the [Elephant carbon intensity provider]({{< relref "carbon-intensity-elephant-machine" >}})
+  in that case, which can be hosted locally.
+- The free Electricity Maps token is rate-limited. If you run a large number of measurements you
+  may hit the limit and the provider will record an error and skip data for that run.
+- The smallest temporal granularity supported by this provider is 5 minutes. Short-running
+  benchmarks (under a few minutes) will usually have only a single carbon intensity value
+  associated with them.
+- The carbon intensity returned by Electricity Maps is a grid average, not a marginal value. If
+  you need marginal values you have to compute them yourself based on the Electricity Maps
+  *power-breakdown* endpoint, which is not supported by this provider.
+
+### Troubleshooting
+
+- *"Electricity Maps token was rejected"* — Check that the `token`
+  field on the provider is set to a valid token from
+  [https://api-portal.electricitymaps.com/](https://api-portal.electricitymaps.com/).
+- *"Electricity Maps base URL ... could not be reached"* — Check the network connectivity of the
+  measurement machine and that no firewall blocks `api.electricitymaps.com`.
+- Empty time series in the frontend — The run was likely too short and even the forecast endpoint
+  did not return a usable value. Increase the run duration or use the Elephant provider.

--- a/content/en/docs/measuring/metric-providers/carbon-intensity-elephant-machine.md
+++ b/content/en/docs/measuring/metric-providers/carbon-intensity-elephant-machine.md
@@ -10,7 +10,7 @@ weight: 221
 This provider fetches the carbon intensity (gCO2e/kWh) of the electricity grid from a self-hosted
 or remotely hosted [Elephant](https://github.com/green-coding-solutions/elephant) service.
 Elephant is a small HTTP service developed by us which aggregates carbon
-intensity data from multiple upstream sources (e.g. Bundesnetzagentur, Electrcity Maps, ...) and exposes
+intensity data from multiple upstream sources (e.g. Bundesnetzagentur, Electricity Maps, ...) and exposes
 them through a uniform REST interface. It also offers the ability to *simulate* arbitrary carbon
 intensity curves so that the same workload can be re-evaluated under different grid scenarios.
 

--- a/content/en/docs/measuring/metric-providers/carbon-intensity-elephant-machine.md
+++ b/content/en/docs/measuring/metric-providers/carbon-intensity-elephant-machine.md
@@ -1,0 +1,160 @@
+---
+title: "Carbon Intensity - Elephant - Machine"
+description: "Documentation for CarbonIntensityElephantMachineProvider of the Green Metrics Tool"
+date: 2026-05-11T08:49:15+00:00
+weight: 221
+---
+
+### What it does
+
+This provider fetches the carbon intensity (gCO2e/kWh) of the electricity grid from a self-hosted
+or remotely hosted [Elephant](https://github.com/green-coding-solutions/elephant) service.
+Elephant is a small HTTP service developed by us which aggregates carbon
+intensity data from multiple upstream sources (e.g. Bundesnetzagentur, Electrcity Maps, ...) and exposes
+them through a uniform REST interface. It also offers the ability to *simulate* arbitrary carbon
+intensity curves so that the same workload can be re-evaluated under different grid scenarios.
+
+This provider integrates Elephant into the Green Metrics Tool so that every run automatically
+gets a carbon intensity time series for the configured region and data provider attached to it
+without leaking any information to a third party.
+
+### Classname
+
+- `CarbonIntensityElephantMachineProvider`
+
+### Metric Name
+
+- `carbon_intensity_elephant_machine`
+
+### Unit
+
+- `gCO2e/kWh`
+
+The provider stores integer values. The API returns floating point numbers which are rounded to
+the nearest integer before being persisted.
+
+### Prerequisites & Installation
+
+The provider is a pure Python provider and does not need any binary to be compiled. It does
+however require a reachable Elephant service. Elephant can be self-hosted via Docker; please
+follow the instructions in the
+[Elephant repository](https://github.com/green-coding-solutions/elephant) for the setup.
+
+The provider must be configured in the `config.yml`:
+
+```yml
+measurement:
+  metric-providers:
+    common:
+      carbon_intensity_elephant_machine:
+        region: 'DE'
+        sampling_rate: 99 # Remove if you don't want value padding
+        provider: 'bundesnetzagentur'
+        elephant:
+          host: localhost
+          port: 8085
+          protocol: http
+```
+
+Please see [Configuration →]({{< relref "/docs/measuring/configuration" >}}) for further info.
+
+### Input Parameters
+
+- `region` — The region identifier as understood by Elephant (e.g. `DE`, `FR`). The list of
+  supported regions depends on which upstream providers your Elephant instance has configured.
+- `provider` — The name of the carbon intensity data provider in Elephant to use (e.g.
+  `bundesnetzagentur`, `entsoe`).
+- `elephant.host` — Host name or IP of the Elephant service.
+- `elephant.port` — Port the Elephant service listens on (default `8085`).
+- `elephant.protocol` — `http` or `https`.
+- `sampling_rate` — The sampling rate in milliseconds. As with the Electricity Maps provider this
+  is used to *pad* the returned values so they align with the time series of the other providers
+  rather than to query the API more often.
+
+### Output
+
+The provider does not produce a continuous Stdout stream. Once per run it queries the Elephant
+service and writes the results directly to the database as a metric of the run.
+
+Each row consists of:
+
+- `time`: The timestamp of the data point in microseconds (UNIX epoch).
+- `value`: The carbon intensity at that point in time in `gCO2e/kWh` as an integer.
+- `detail_name`: The name of the Elephant carbon provider that produced the value
+  (e.g. `bundesnetzagentur_de`). For carbon simulation runs this is the simulation UUID.
+
+Any errors that occur while talking to the Elephant service are appended to the provider's stderr
+buffer and can be inspected in the run details in the frontend.
+
+### How it works
+
+On `start_profiling` and `stop_profiling` the provider records UTC timestamps. When the metrics
+are read at the end of the run it issues a single HTTP GET request to
+
+```
+<protocol>://<host>:<port>/carbon-intensity/history
+```
+
+with the configured `region`, the start/end times of the run, the `provider` filter, and
+`update=true` so that Elephant re-fetches stale data from its upstream sources before responding.
+The response is a list of `{time, carbon_intensity, provider}` entries which are sorted, rounded
+to integer values and expanded to the configured `sampling_rate`.
+
+If the response is empty — which typically happens for very short runs because upstream providers
+update at intervals between 5 minutes and one hour — the provider falls back to:
+
+```
+<protocol>://<host>:<port>/carbon-intensity/current
+```
+
+(or `/carbon-intensity/current/primary` if no provider filter is configured) and uses the most
+recent value as a single data point so that the run is never left without a carbon intensity.
+
+### Health check
+
+When the provider starts, it issues an HTTP GET against `/health` on the configured Elephant URL.
+The service is expected to respond with a JSON body containing `{"status": "healthy"}`. If the
+service is not reachable, returns a different status, or the response cannot be parsed, the
+provider raises a `MetricProviderConfigurationError` and the run will not start.
+
+### Carbon simulation
+
+The Elephant provider is also used by the Green Metrics Tool to drive *carbon simulations*. When
+running the runner with `--carbon-simulation <value>`:
+
+- If `<value>` is a UUID, the simulation with that ID is used.
+- If `<value>` is a list of carbon values, the runner first POSTs it to Elephant's `/simulation`
+  endpoint to register a new simulation, and then uses the returned UUID for the run.
+- If `<value>` is a single integer, that fixed intensity is applied to the whole run.
+
+For simulation runs the provider sends `simulationId=<uuid>` as an additional query parameter to
+Elephant which then returns the simulated carbon intensity curve instead of the real grid data.
+Carbon simulations are useful to answer "what if?" questions such as how a workload would have
+behaved on a grid with a different generation mix without re-running the workload.
+
+See the `--carbon-simulation` argument of `runner.py` for more details.
+
+### Caveats
+
+- The provider requires that the Elephant service is reachable from the measurement machine. If
+  Elephant is hosted on a different network, make sure that firewalls and routing allow the
+  connection.
+- The smallest temporal granularity supported by this provider depends on the upstream data
+  provider configured in Elephant. Bundesnetzagentur for example updates roughly every 15 minutes.
+- The fallback to the `current` endpoint will yield only a single data point. Long runs should
+  therefore always observe enough upstream data to avoid the fallback path.
+- Like all carbon intensity numbers in the Green Metrics Tool the values are stored as integers.
+  Sub-`g/kWh` precision is lost;
+
+### Troubleshooting
+
+- *"Elephant base URL ... could not be reached"* — Check that `elephant.host`, `elephant.port`,
+  and `elephant.protocol` are correct and that the Elephant service is running. Try
+  `curl <protocol>://<host>:<port>/health` from the measurement machine.
+- *"Elephant service health check failed"* — Elephant responded but did not report `healthy`.
+  Check the Elephant logs for missing upstream credentials or unreachable upstream APIs.
+- *"Please set the provider config option ..."* — You configured the provider without a
+  `provider` entry and the run is not a carbon simulation. Either set `provider` in the
+  `config.yml` or run with `--carbon-simulation`.
+- Empty time series in the frontend — The run was too short and even the fallback endpoint did
+  not return a value. Increase the run duration or use a simulation.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Added documentation for two carbon provider metrics:

1. **CarbonIntensityElectricitymapsMachineProvider** - Documents provider that fetches electricity grid carbon intensity from the Electricity Maps API, with support for aligning data to measurement windows, fallback from past-range to forecast, and comprehensive troubleshooting guidance. (+143 lines)

2. **CarbonIntensityElephantMachineProvider** - Documents provider that fetches carbon intensity time series from a self- or remotely hosted Elephant service, including configuration requirements, runtime workflow with fallback behavior, carbon simulation support, and error handling guidance. (+160 lines)

Both documentation additions are comprehensive, covering provider identification, unit/storage behavior, configuration prerequisites, schema information, health check behavior, operational caveats, and troubleshooting guidance for common errors.

**Total lines added:** 303  
**Scope:** Documentation only; no code changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/green-coding-solutions/documentation/pull/136)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->